### PR TITLE
chore: update cachix flakes image tag

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -48,6 +48,7 @@ source:
 type: registry-image
 source:
   repository: ghcr.io/nix-community/docker-nixpkgs/cachix-flakes
+  tag: latest-x86_64-linux
 #@ end
 
 #@ def check_code():


### PR DESCRIPTION
The `latest` tagged image for cachix-flakes on ghcr is [2 years old](https://github.com/nix-community/docker-nixpkgs/pkgs/container/docker-nixpkgs%2Fcachix-flakes/77852010?tag=latest). This tag makes sure we pull in the latest one.
