### PR TITLE
chore: migrate from kaniko to oci-build-task

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -38,27 +38,21 @@ groups:
 
 #@ def build_task(input_name, context_path):
 task: build
+privileged: true
 config:
   platform: linux
   image_resource:
     type: registry-image
     source:
-      repository: gcr.io/kaniko-project/executor
-      tag: debug
+      repository: concourse/oci-build-task
   inputs:
   - name: #@ input_name
   outputs:
   - name: image
   run:
-    path: /kaniko/executor
-    args:
-      - --dockerfile=Dockerfile
-      - #@ "--context=" + context_path
-      - --use-new-run
-      - --single-snapshot
-      - --cache=false
-      - --no-push
-      - --tar-path=image/image.tar
+    path: build
+  params:
+    CONTEXT: #@ context_path
 #@ end
 
 jobs:

--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -210,27 +210,22 @@ plan:
     run:
       path: pipeline-tasks/ci/vendor/tasks/docker-prep-docker-build-env.sh
 - task: build
+  privileged: true
   config:
     platform: linux
     image_resource:
       type: registry-image
       source:
-        repository: gcr.io/kaniko-project/executor
-        tag: debug
+        repository: concourse/oci-build-task
     inputs:
     - name: repo
     outputs:
     - name: image
+    params:
+      CONTEXT: repo
+      DOCKERFILE: repo/Dockerfile
     run:
-      path: /kaniko/executor
-      args:
-        - --dockerfile=Dockerfile
-        - --context=repo
-        - --use-new-run
-        - --single-snapshot
-        - --cache=false
-        - --no-push
-        - --tar-path=image/image.tar
+      path: build
 - put: edge-image
   params:
     image: image/image.tar


### PR DESCRIPTION
## Summary
- Migrate `build_task()` function in `ci/pipeline.yml` from Kaniko to oci-build-task
- Migrate `build_edge_image()` function in `shared/ci/pipeline-fragments.lib.yml` from Kaniko to oci-build-task
- Kaniko has been deprecated

## Test plan
- [ ] Verify CI pipeline runs successfully
- [ ] Verify images are built correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)