### PR TITLE
fix: add fly to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,46 @@
     flake-utils.lib.eachDefaultSystem (
       system: let
         pkgs = import nixpkgs {inherit system;};
+        concourseFly = let
+          artifacts = {
+            x86_64-linux = {
+              arch = "amd64";
+              platform = "linux";
+              hash = "sha256-Oc6KJcmaFF1+UVXXP32w/HTUHj8blHnqR81tNdb3ppk=";
+            };
+            aarch64-linux = {
+              arch = "arm64";
+              platform = "linux";
+              hash = "sha256-wIpb9o6YVsV8Rt8EalNCFJHUHB6h9yc7uYU+dTJfEf8=";
+            };
+            x86_64-darwin = {
+              arch = "amd64";
+              platform = "darwin";
+              hash = "sha256-K8XrRI8HKunujq4OI201iSfdTwGm/MScGaGB8Ytf0+g=";
+            };
+            aarch64-darwin = {
+              arch = "arm64";
+              platform = "darwin";
+              hash = "sha256-yJwC+ENHt28hmznAsW2/hwDdpZYyQSkTQwNxKg6RbK4=";
+            };
+          };
+          artifact = artifacts.${system} or (throw "Unsupported fly platform: ${system}");
+        in
+          pkgs.stdenvNoCC.mkDerivation {
+            pname = "fly";
+            version = "8.1.1";
+
+            src = pkgs.fetchurl {
+              url = "https://ci.galoy.io/api/v1/cli?arch=${artifact.arch}&platform=${artifact.platform}";
+              hash = artifact.hash;
+            };
+
+            dontUnpack = true;
+
+            installPhase = ''
+              install -D -m755 "$src" "$out/bin/fly"
+            '';
+          };
       in
         with pkgs; {
           packages = rec {
@@ -36,6 +76,7 @@
             nativeBuildInputs = [
               ytt
               alejandra
+              concourseFly
             ];
           };
           formatter = alejandra;


### PR DESCRIPTION
## Summary
- add Concourse fly 8.1.1 to the Nix dev shell
- ensures ci/repipe has both ytt and fly available from nix develop

## Verification
- `alejandra flake.nix`
- `nix develop --command sh -c 'which fly; fly --version; which ytt; ytt version'`