### PR TITLE
ci: remove wincross concourse image build

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -29,7 +29,6 @@ groups:
 - name: images
   jobs:
   - build-rust-concourse-image
-  - build-wincross-pipeline-image
   - build-release-pipeline-image
 - name: backups
   jobs:
@@ -73,17 +72,6 @@ jobs:
   - put: release-pipeline-image
     params:
       image: image/image.tar
-
-- name: build-wincross-pipeline-image
-  serial: true
-  plan:
-  - get: wincross-pipeline-image-def
-    trigger: true
-  - #@ build_task("wincross-pipeline-image-def", "wincross-pipeline-image-def/images/wincross")
-  - put: wincross-pipeline-image
-    params:
-      image: image/image.tar
-
 
 #@ for repo in data.values.src_repos:
 - name: #@ "bump-shared-files-in-" + repo
@@ -218,22 +206,6 @@ resources:
   type: git
   source:
     paths: [images/release/Dockerfile]
-    uri: #@ data.values.git_uri
-    branch: #@ data.values.git_branch
-    private_key: #@ data.values.github_private_key
-
-- name: wincross-pipeline-image
-  type: registry-image
-  source:
-    tag: latest
-    username: #@ data.values.gar_registry_user
-    password: #@ data.values.gar_registry_password
-    repository: #@   data.values.docker_registry + "/wincross-rust"
-
-- name: wincross-pipeline-image-def
-  type: git
-  source:
-    paths: [images/wincross/Dockerfile]
     uri: #@ data.values.git_uri
     branch: #@ data.values.git_branch
     private_key: #@ data.values.github_private_key

--- a/images/wincross/Dockerfile
+++ b/images/wincross/Dockerfile
@@ -1,7 +1,0 @@
-FROM rust:latest
-
-RUN apt update && apt upgrade -y
-RUN apt install -y g++-mingw-w64-x86-64
-
-RUN rustup target add x86_64-pc-windows-gnu
-RUN rustup toolchain install stable-x86_64-pc-windows-gnu


### PR DESCRIPTION
## Summary
- remove the unused build-wincross-pipeline-image job from the shared Concourse pipeline
- remove the wincross image resources from the pipeline
- delete the now-unused wincross Dockerfile

## Verification
- `ytt -f ci > /tmp/concourse-shared-no-wincross.yml`
- confirmed the rendered pipeline no longer contains `wincross`, `wincross-rust`, or `build-wincross`