### PR TITLE
ci: sync rust libs to shared concourse src_repos

### DIFF
--- a/ci/values.yml
+++ b/ci/values.yml
@@ -21,5 +21,7 @@ source_repo_branch: main
 
 src_repos:
   bria: ["rust", "docker", "chart"]
-  cala: ["rust", "docker"]
+  cala: ["rust"]
+  job: ["rust"]
+  obix: ["rust"]
   lana-bank: ["rust", "docker"]

--- a/ci/values.yml
+++ b/ci/values.yml
@@ -24,4 +24,3 @@ src_repos:
   cala: ["rust"]
   job: ["rust"]
   obix: ["rust"]
-  lana-bank: ["rust", "docker"]


### PR DESCRIPTION
## What

Clean up `ci/values.yml` `src_repos` to reflect the actual shared-CI consumers:

- **`job`, `obix`** — added with `["rust"]`. They currently carry **frozen hand-copies** of the vendored CI (never bot-synced, missing the `Auto synced` header, pinned at an old shared ref). Adding them puts them in the auto-bump loop.
- **`cala`** — dropped the `docker` feature (`["rust","docker"]` → `["rust"]`). cala builds no image, so the `docker-*` task scripts were vendored but unused. Next bump removes them.
- **`lana-bank`** — **removed**. It no longer consumes shared CI: no `ci/vendir.yml`, no `ci/vendor` tree, home-grown GitHub Actions, and its own `ci/release` pipeline (builds its image via nix, not the shared docker path). Its `bump-shared-tasks` PRs have gone unmerged since 2025-03, so the entry only generates dead PRs.

## Not included

- **`es-entity`** — deliberately left out. Its `prep-release-src.sh` is customized for pre-0.x semver bumping and the generic shared script would clobber it. (Follow-up: upstream that 0.x logic into shared, then add es-entity.)

## After merge

Requires `ci/repipe` to (a) create the `bump-shared-files-in-{job,obix}` jobs and (b) remove the lana-bank job/resources. Then trigger the bump jobs for cala/job/obix and review the resulting PRs (they re-sync the full vendor tree + re-stamp the GH action workflows).

🤖 Generated with [Claude Code](https://claude.com/claude-code)