### PR TITLE
ci: fix backup task image

### DIFF
--- a/ci/pipeline.yml
+++ b/ci/pipeline.yml
@@ -125,10 +125,7 @@ jobs:
   - task: gcp-backup
     config:
       platform: linux
-      image_resource:
-        type: registry-image
-        source:
-          repository: us.gcr.io/galoyorg/galoy-dev
+      image_resource: #@ task_image_config()
       inputs:
       - name: pipeline-tasks
       params:


### PR DESCRIPTION
## Summary
- switch `backup-org-to-gcp` to the existing credentialed pipeline task image
- stop using missing `us.gcr.io/galoyorg/galoy-dev:latest` for the backup task

## Evidence
- Concourse build `backup-org-to-gcp/97` errored before the backup script emitted logs
- `us.gcr.io/galoyorg/galoy-dev:latest` returns `MANIFEST_UNKNOWN`

## Validation
- `ytt -f ci/pipeline.yml -f ci/values.yml > /tmp/concourse-shared-fixed.yml`
- `fly validate-pipeline --config /tmp/concourse-shared-fixed.yml`
