### PR TITLE
ci: use ghtoken in backup task

### DIFF
--- a/ci/tasks/gcp-backup.sh
+++ b/ci/tasks/gcp-backup.sh
@@ -11,7 +11,7 @@ EOF
 
 gcloud auth activate-service-account --key-file ${CI_ROOT}/gcloud-creds.json
 
-export GH_TOKEN="$(gh-token generate -b "${GH_APP_PRIVATE_KEY}" -i "${GH_APP_ID}" | jq -r '.token')"
+export GH_TOKEN="$(ghtoken generate -b "${GH_APP_PRIVATE_KEY}" -i "${GH_APP_ID}" | jq -r '.token')"
 
 # no API keys up to 4,000 private repos.
 gh repo list ${ORG_NAME} --limit 4000 | while read -r repo _; do


### PR DESCRIPTION
## Summary
- use the installed `ghtoken` binary in `gcp-backup.sh`

## Evidence
- `backup-org-to-gcp/98` reached the script after the image fix, then failed with `gh-token: command not found`
- the pipeline image installs `/usr/local/bin/ghtoken`

## Validation
- `git diff --check`
