### PR TITLE
feat(ci): reusable self-bootstrapping fuzz_job + fuzz.sh

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -457,3 +457,145 @@ type: docker-image
 source:
   repository: timotto/concourse-npm-resource
 #@ end
+
+#! ── Fuzzing (cargo-fuzz / libFuzzer) ────────────────────────────────
+#! A self-bootstrapping nightly fuzz job. The corpus is persisted to GCS via
+#! gsutil (NOT a Concourse gcs-resource — nixpkgs google-cloud-sdk's gsutil is
+#! broken with an EVP_MD_CTX_new crypto mismatch, so GCS access uses the
+#! google/cloud-sdk image). First run finds no corpus and fuzzes from scratch.
+#!
+#! A repo adopts fuzzing by shipping a `fuzz/` cargo-fuzz crate and including
+#! `fuzz_job()` plus the fuzz-time + zenduty resources/types below. Credentials:
+#! reuses the shared `staging-gcp-creds` (same as bundled_deps_resource); swap
+#! for a dedicated fuzz credential in the job if that isn't available.
+
+#@ def fuzz_time_resource():
+name: fuzz-time
+type: time
+source:
+  #! Weekly: Saturday 06:00–07:00 UTC. The job is still manually triggerable
+  #! via `fly trigger-job -j <pipeline>/fuzz`.
+  location: "UTC"
+  start: "6:00 AM"
+  stop: "7:00 AM"
+  days: ["Saturday"]
+#@ end
+
+#@ def zenduty_notification_hook():
+put: zenduty-notification
+params:
+  alert_type: non-critical
+#@ end
+
+#@ def zenduty_notification_resource():
+name: zenduty-notification
+type: zenduty-notification
+source:
+  webhook_url: #@ data.values.zenduty_webhook_url
+#@ end
+
+#@ def zenduty_resource_type():
+name: zenduty-notification
+type: registry-image
+source:
+  username: #@ data.values.gar_registry_user
+  password: #@ data.values.gar_registry_password
+  repository: #@ public_docker_registry() + "/zenduty-notification-resource"
+  tag: edge
+#@ end
+
+#@ def fuzz_job(fuzz_seconds="86400"):
+name: fuzz
+serial: true
+plan:
+- in_parallel:
+  - { get: repo }
+  - { get: pipeline-tasks }
+  - { get: fuzz-time, trigger: true }
+- task: restore-corpus
+  config:
+    platform: linux
+    image_resource:
+      type: registry-image
+      source: { repository: google/cloud-sdk }
+    outputs:
+    - { name: corpus }
+    params:
+      GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+      GCS_CREDS: ((staging-gcp-creds.creds_json))
+      GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+    run:
+      path: sh
+      args:
+      - -exc
+      - |
+        set -euo pipefail
+        mkdir -p corpus
+        printf '%s' "$GCS_CREDS" > /tmp/key.json
+        gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+        prefix="gs://$GCS_BUCKET/$GCS_PREFIX"
+        latest="$(gsutil ls "$prefix/corpus-v*.tgz" 2>/dev/null | sort | tail -1 || true)"
+        if [ -n "$latest" ]; then
+          echo "restoring corpus from $latest"
+          gsutil cp "$latest" corpus/
+        else
+          echo "no existing corpus; bootstrapping from scratch"
+        fi
+- task: fuzz
+  config:
+    platform: linux
+    image_resource: #@ nix_task_image_config()
+    inputs:
+    - { name: repo }
+    - { name: corpus }
+    outputs:
+    - { name: corpus-out }
+    caches:
+    - { path: cargo-home }
+    - { path: cargo-target-dir }
+    run:
+      path: sh
+      args:
+      - -exc
+      - |
+        set -euo pipefail
+        cd repo
+        cachix use $CACHIX_CACHE_NAME
+        cachix watch-exec $CACHIX_CACHE_NAME -- nix -L develop . -c sh -exc '
+          set -euo pipefail
+          export CARGO_HOME=$PWD/../cargo-home
+          export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
+          export CORPUS_TARBALL_IN="../corpus/*.tgz"
+          export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
+          bash pipeline-tasks/ci/vendor/tasks/fuzz.sh
+        '
+    params:
+      CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
+      CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
+      FUZZ_SECONDS: #@ fuzz_seconds
+- task: store-corpus
+  config:
+    platform: linux
+    image_resource:
+      type: registry-image
+      source: { repository: google/cloud-sdk }
+    inputs:
+    - { name: corpus-out }
+    params:
+      GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+      GCS_CREDS: ((staging-gcp-creds.creds_json))
+      GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+    run:
+      path: sh
+      args:
+      - -exc
+      - |
+        set -euo pipefail
+        if ! ls corpus-out/*.tgz >/dev/null 2>&1; then echo "no corpus to store; nothing was packaged"; exit 0; fi
+        printf '%s' "$GCS_CREDS" > /tmp/key.json
+        gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+        gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+        echo "stored corpus"
+on_failure: #@ zenduty_notification_hook()
+on_error: #@ zenduty_notification_hook()
+#@ end

--- a/shared/ci/tasks/fuzz.sh
+++ b/shared/ci/tasks/fuzz.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+
+#! Shared cargo-fuzz runner — the single source of truth for fuzzing logic,
+#! vendored from galoy-concourse-shared into each repo's ci/vendor/tasks/.
+#!
+#! Used by:
+#!   - the Concourse `fuzz` job (fuzz_job() in pipeline-fragments.lib.yml):
+#!     the restore-corpus / store-corpus steps pass the corpus in/out as a
+#!     tarball via CORPUS_TARBALL_IN/OUT (GCS handled by those gsutil steps)
+#!   - `make fuzz` / a repo-specific flake app, for local runs
+#!
+#! Repo-agnostic: discovers targets via `cargo fuzz list`. The repo must ship a
+#! `fuzz/` cargo-fuzz crate.
+#!
+#! Env vars (all optional):
+#!   FUZZ_SECONDS        seconds to fuzz each target (default: 60)
+#!   FUZZ_JOBS           libFuzzer `-jobs` per target; cores ~= #targets * FUZZ_JOBS
+#!   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
+#!   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
+#!
+#! Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
+
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || pwd)"
+cd "$ROOT"
+
+if ! command -v cargo-fuzz >/dev/null 2>&1; then
+  echo "cargo-fuzz not found on PATH; installing..."
+  cargo install cargo-fuzz --locked
+fi
+
+FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
+
+#! Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
+mkdir -p fuzz/corpus
+if [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
+  echo "restoring corpus from $CORPUS_TARBALL_IN"
+  tar -xzf $CORPUS_TARBALL_IN -C fuzz/
+fi
+
+mapfile -t targets < <(cd fuzz && cargo fuzz list)
+echo "discovered ${#targets[@]} target(s): ${targets[*]}"
+
+(cd fuzz && cargo fuzz build --sanitizer=none)
+
+JOBS_ARG=""
+if [ -n "${FUZZ_JOBS:-}" ]; then
+  JOBS_ARG="-jobs=$FUZZ_JOBS"
+fi
+
+echo "fuzzing ${#targets[@]} target(s) in parallel for ${FUZZ_SECONDS}s${JOBS_ARG:+ ($JOBS_ARG per target)}"
+pids=""
+rc=0
+for target in "${targets[@]}"; do
+  (cd fuzz && cargo fuzz run "$target" --sanitizer=none -- \
+    -max_total_time="$FUZZ_SECONDS" -timeout=25 $JOBS_ARG \
+    -artifact_prefix="artifacts/$target/") &
+  pids="$pids $!"
+done
+for p in $pids; do
+  wait "$p" || rc=1
+done
+
+if [ "$rc" -ne 0 ]; then
+  echo "==== FUZZ CRASH DETECTED ===="
+  find fuzz/artifacts -type f -print || true
+  exit "$rc"
+fi
+
+#! Package the evolved corpus (no-op unless CORPUS_TARBALL_OUT is set).
+if [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
+  mkdir -p "$(dirname "$CORPUS_TARBALL_OUT")"
+  tar -czf "$CORPUS_TARBALL_OUT" -C fuzz corpus
+  echo "packaged corpus -> $CORPUS_TARBALL_OUT"
+fi


### PR DESCRIPTION
## Summary

Adds **coverage-guided fuzzing** (cargo-fuzz / libFuzzer) as a reusable Concourse job, so any Galoy repo can adopt fuzzing by shipping a `fuzz/` crate and including `fuzz_job()`. Extracted from [GaloyMoney/es-entity#191](https://github.com/GaloyMoney/es-entity/pull/191), where the self-bootstrapping design was verified end-to-end on Concourse + GCS (two real runs: bootstrap → fuzz 1h (0 crashes) → store → reuse).

Additive only — existing consumers are unaffected.

**Defaults:** weekly run (Saturday 06:00 UTC), 24h per run. Still manually triggerable via `fly trigger-job -j <pipeline>/fuzz`.

## What's added

### `shared/ci/tasks/fuzz.sh` — repo-agnostic runner
- Discovers targets via `cargo fuzz list` (no hardcoded names).
- Runs all targets in parallel; restores/persists the corpus via `CORPUS_TARBALL_IN`/`CORPUS_TARBALL_OUT` tarballs.
- Auto-installs `cargo-fuzz` if missing; crashes exit non-zero before packaging (so a crashing run isn't persisted).

### `shared/ci/pipeline-fragments.lib.yml`
- **`fuzz_job(fuzz_seconds="86400")`** — a 3-step, self-bootstrapping job:
  1. `restore-corpus` (`google/cloud-sdk`): `gsutil` downloads the latest corpus, or starts empty on first run — **no manual seed**.
  2. `fuzz` (nix): runs the shared `fuzz.sh` with the Rust toolchain (default 24h; override per-repo).
  3. `store-corpus` (`google/cloud-sdk`): `gsutil` uploads the grown corpus.
- **`fuzz_time_resource()`** — weekly trigger: Saturday 06:00–07:00 UTC.
- **`zenduty_notification_hook()` / `zenduty_notification_resource()` / `zenduty_resource_type()`** — crash alerting (previously each repo, e.g. lana-bank, had its own copy).

## Design notes
- **Corpus in GCS, not git**, under `<gh_repository>-artifacts/fuzz-corpus/` (per-repo), reusing the shared `staging-gcp-creds`.
- **GCS via gsutil in the `google/cloud-sdk` image, NOT a Concourse `gcs-resource`** and NOT nix's gsutil: nixpkgs `google-cloud-sdk`'s gsutil fails with `module 'lib' has no attribute 'EVP_MD_CTX_new'` (bundled-cryptography/OpenSSL mismatch); the cloud-sdk image's gsutil works.
- Self-bootstrap means the first run of any repo just works — empty bucket → fuzz from scratch → upload.

## How a repo adopts it (follow-up PRs per repo)
1. Ship a `fuzz/` cargo-fuzz crate with targets.
2. In `ci/pipeline.yml`: `#@ fuzz_job()` (+ `fuzz_time_resource()`, zenduty resource/type, and `zenduty_webhook_url` in values). Override `fuzz_job(fuzz_seconds="…")` for a non-default duration.
3. Bump the `vendir` ref to pick up this change.

## Verification
- Rendered a minimal consumer pipeline with `ytt` → correct 3-step structure, weekly trigger (Sat 06:00 UTC), 24h default, per-repo `GCS_PREFIX`, `on_failure` hook.
- `bash -n` on `fuzz.sh`.
- The underlying job design (identical to es-entity's) was verified end-to-end on Concourse: two real runs confirmed bootstrap, fuzz with zero crashes, gsutil store, and reuse of the uploaded corpus.
