### PR TITLE
fix(ci): fuzz_job runs the repo's vendored fuzz.sh

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -567,7 +567,7 @@ plan:
           export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
           export CORPUS_TARBALL_IN="../corpus/*.tgz"
           export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
-          bash pipeline-tasks/ci/vendor/tasks/fuzz.sh
+          bash ci/vendor/tasks/fuzz.sh
         '
     params:
       CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token


### PR DESCRIPTION
The shared `fuzz_job` runs `bash pipeline-tasks/ci/vendor/tasks/fuzz.sh`, but the fuzz task does `cd repo` and doesn't have `pipeline-tasks` as an input. The repo input already contains the vendored `ci/vendor/tasks/fuzz.sh`, so the path must be repo-relative. The old path failed at runtime with `No such file or directory` (found while running es-entity's migrated fuzz job end-to-end on Concourse).

Verified: with this fix, es-entity's fuzz run reaches the shared `fuzz.sh` (`discovered 2 target(s)`) and fuzzes correctly.