### PR TITLE
fix(fuzz): make corpus restore portable (compgen → ls)

### DIFF
--- a/shared/ci/tasks/fuzz.sh
+++ b/shared/ci/tasks/fuzz.sh
@@ -34,7 +34,7 @@ FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
 #! Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
 mkdir -p fuzz/corpus
-if [ -n "${CORPUS_TARBALL_IN:-}" ] && compgen -G "$CORPUS_TARBALL_IN" >/dev/null; then
+if [ -n "${CORPUS_TARBALL_IN:-}" ] && ls -d $CORPUS_TARBALL_IN >/dev/null 2>&1; then
   echo "restoring corpus from $CORPUS_TARBALL_IN"
   tar -xzf $CORPUS_TARBALL_IN -C fuzz/
 fi


### PR DESCRIPTION
fix(fuzz): make corpus restore portable (compgen → ls)

The shared fuzz.sh gated corpus extraction on `compgen -G "$CORPUS_TARBALL_IN"`,
a bash builtin. In the fuzz task's shell that builtin is unavailable — every
run logs `ci/vendor/tasks/fuzz.sh: line 37: compgen: command not found`, the
`&&` short-circuits, and the restored tarball is downloaded by restore-corpus
but never extracted. Net effect: the corpus is stored to GCS each run yet
never loaded back, so every run fuzzes from scratch and coverage does NOT
accumulate across runs (the whole point of persisting the corpus).

Confirmed in production logs:
  es-entity/fuzz/8:  ci/vendor/tasks/fuzz.sh: line 37: compgen: command not found
  obix/fuzz/*:       same

Replace `compgen -G <glob>` with `ls -d <glob>`, the POSIX-portable equivalent
(verified: match → exit 0 → extract; no match → exit non-zero → skip). No
behavior change beyond actually extracting the tarball.

This is the real bootstrap issue behind "I thought this was fixed" — it's not
GCS seeding (the job is already self-bootstrapping); it's that the restored
corpus was silently discarded.
