### PR TITLE
feat(fuzz): merge fuzz/seeds/<target>/ into the corpus before each run

### DIFF
--- a/shared/ci/tasks/fuzz.sh
+++ b/shared/ci/tasks/fuzz.sh
@@ -18,6 +18,12 @@
 #!   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
 #!   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
 #!
+#! A repo may optionally ship a curated seed corpus at `fuzz/seeds/<target>/`
+#! (one input per file). It is merged into `fuzz/corpus/<target>/` before every
+#! run, after the stored corpus is restored — so coverage re-bootstraps even if
+#! the stored corpus is pruned, and seed changes travel with the code. Repos
+#! without `fuzz/seeds/` are unaffected (backward compatible).
+#!
 #! Requires: bash, git, cargo, tar, and cargo-fuzz (auto-installed if missing).
 
 set -euo pipefail
@@ -41,6 +47,21 @@ fi
 
 mapfile -t targets < <(cd fuzz && cargo fuzz list)
 echo "discovered ${#targets[@]} target(s): ${targets[*]}"
+
+#! Merge any committed seed corpus (fuzz/seeds/<target>/) into fuzz/corpus/.
+#! Optional + backward compatible: skipped per-target when the dir is absent,
+#! so repos without seeds (e.g. es-entity) are unaffected. Done after the
+#! stored corpus is restored and per discovered target (no phantom corpus dirs
+#! for stale seed folders). libFuzzer de-duplicates, so re-merging each run is
+#! cheap and keeps the curated baseline present even if the corpus is pruned.
+for target in "${targets[@]}"; do
+  seed_dir="fuzz/seeds/$target"
+  [ -d "$seed_dir" ] || continue
+  mkdir -p "fuzz/corpus/$target"
+  # `/.` copies the directory's contents (incl. dotfiles) into the corpus.
+  cp -R "$seed_dir"/. "fuzz/corpus/$target/" 2>/dev/null || true
+done
+[ -d fuzz/seeds ] && echo "merged fuzz/seeds/ into fuzz/corpus/"
 
 (cd fuzz && cargo fuzz build --sanitizer=none)
 


### PR DESCRIPTION
## What

`fuzz.sh` now merges an optional committed seed corpus at `fuzz/seeds/<target>/` into `fuzz/corpus/<target>/` before each fuzz run.

## Why

Today `fuzz.sh` only manages `fuzz/corpus/` (restored/stored via GCS) and never looks at `fuzz/seeds/`. So a repo that wants to ship curated seed inputs (to bootstrap coverage for structured targets) has no supported way to get them into the corpus — they're ignored in CI.

This came up in cala, whose multi-document targets (e.g. `velocity_enforce` = five JSON docs joined by `0xFF`) gain coverage very slowly from random bytes and really need a seed set.

## How

After `cargo fuzz list` discovers targets, for each one with a `fuzz/seeds/<target>/` directory, copy its contents into `fuzz/corpus/<target>/` (additive, over the restored GCS corpus).

## Compatibility

- **Backward compatible by construction:** the merge is skipped per-target when `fuzz/seeds/<target>` is absent. Repos with no `fuzz/seeds/` (es-entity) are completely unchanged.
- Done per *discovered* target, so stale seed folders don't create phantom corpus dirs.
- Additive + libFuzzer de-duplicates, so re-merging every run is cheap and keeps the curated baseline present even if the stored GCS corpus is pruned.

## Test plan
- [x] unit-tested the merge loop: additive over an existing corpus file; empty seed dir is a no-op; target without a seed dir leaves no corpus dir; absence of `fuzz/seeds/` entirely is a no-op (es-entity parity)
- [ ] cala bumps its vendir ref to this commit and re-commits its `fuzz/seeds/` (follow-up PR)
