### PR TITLE
feat(fuzz): default SQLX_OFFLINE=true in the fuzz build

### DIFF
--- a/shared/ci/tasks/fuzz.sh
+++ b/shared/ci/tasks/fuzz.sh
@@ -32,6 +32,13 @@ fi
 
 FUZZ_SECONDS="${FUZZ_SECONDS:-60}"
 
+#! Build with the committed SQLx offline cache (.sqlx/) instead of connecting to
+#! a database — there is no Postgres in a fuzz build, and coverage-guided fuzzing
+#! wants pure, deterministic targets anyway. Harmless for non-SQLx repos (the
+#! var is ignored) and overridable via the environment. Mirrors what each repo's
+#! local `make fuzz` already does.
+export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
+
 #! Restore the corpus (no-op unless CORPUS_TARBALL_IN is set and matches a file).
 mkdir -p fuzz/corpus
 if [ -n "${CORPUS_TARBALL_IN:-}" ] && ls -d $CORPUS_TARBALL_IN >/dev/null 2>&1; then


### PR DESCRIPTION
## What

`fuzz.sh` now defaults `SQLX_OFFLINE=true` for the fuzz build.

## Why

cargo-fuzz builds the fuzz crate, which (for SQLx repos — cala, es-entity) pulls in sqlx's compile-time query checking. With `SQLX_OFFLINE` unset, sqlx tries to connect to a Postgres that doesn't exist in a fuzz build, and the whole thing dies:

```
error: error communicating with database: Connection refused (os error 111)
error: could not compile `job` (lib) due to 49 previous errors
```

This surfaced running cala's `fuzz` job for the first time (its `cala-ledger` crate uses sqlx). es-entity's fuzz crate has the same shape, so it's affected too.

## The change

```sh
export SQLX_OFFLINE="${SQLX_OFFLINE:-true}"
```

- Uses the committed `.sqlx/` offline cache instead of a live DB — correct for a fuzz build (no Postgres available; coverage-guided fuzzing wants pure, deterministic targets anyway).
- **Harmless for non-SQLx repos** — the variable is simply ignored.
- Overridable via the environment (`SQLX_OFFLINE=false ...`) if a repo ever wants otherwise.
- Mirrors what each repo's local `make fuzz` already sets; makes the shared runner correct out of the box.

## Test plan
- [x] cala's `fuzz` job: with this (via the repo's `SQLX_OFFLINE=true`), the build succeeds and the full cycle runs — restore-corpus → seed-merge → build → 180s fuzz (9 targets) → store-corpus to GCS, build status `succeeded`.
- [ ] cala bumps its vendir ref to this commit (follow-up).
