### PR TITLE
fix(fuzz): preserve corpus + artifacts when a target crashes

### DIFF
--- a/shared/ci/pipeline-fragments.lib.yml
+++ b/shared/ci/pipeline-fragments.lib.yml
@@ -550,6 +550,7 @@ plan:
     - { name: corpus }
     outputs:
     - { name: corpus-out }
+    - { name: artifacts-out }
     caches:
     - { path: cargo-home }
     - { path: cargo-target-dir }
@@ -567,35 +568,61 @@ plan:
           export CARGO_TARGET_DIR=$PWD/../cargo-target-dir
           export CORPUS_TARBALL_IN="../corpus/*.tgz"
           export CORPUS_TARBALL_OUT="../corpus-out/corpus-v$(date -u +%Y%m%d-%H%M%S).tgz"
+          export ARTIFACTS_TARBALL_OUT="../artifacts-out/artifacts-v$(date -u +%Y%m%d-%H%M%S).tgz"
           bash ci/vendor/tasks/fuzz.sh
         '
     params:
       CACHIX_AUTH_TOKEN: #@ data.values.cachix_auth_token
       CACHIX_CACHE_NAME: #@ data.values.cachix_cache_name
       FUZZ_SECONDS: #@ fuzz_seconds
-- task: store-corpus
-  config:
-    platform: linux
-    image_resource:
-      type: registry-image
-      source: { repository: google/cloud-sdk }
-    inputs:
-    - { name: corpus-out }
-    params:
-      GCS_BUCKET: ((staging-gcp-creds.bucket_name))
-      GCS_CREDS: ((staging-gcp-creds.creds_json))
-      GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
-    run:
-      path: sh
-      args:
-      - -exc
-      - |
-        set -euo pipefail
-        if ! ls corpus-out/*.tgz >/dev/null 2>&1; then echo "no corpus to store; nothing was packaged"; exit 0; fi
-        printf '%s' "$GCS_CREDS" > /tmp/key.json
-        gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
-        gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
-        echo "stored corpus"
+  ensure:
+    do:
+    - task: store-corpus
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: { repository: google/cloud-sdk }
+        inputs:
+        - { name: corpus-out }
+        params:
+          GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+          GCS_CREDS: ((staging-gcp-creds.creds_json))
+          GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-corpus"
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            set -euo pipefail
+            if ! ls corpus-out/*.tgz >/dev/null 2>&1; then echo "no corpus to store; nothing was packaged"; exit 0; fi
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            gsutil cp corpus-out/corpus-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+            echo "stored corpus"
+    - task: store-artifacts
+      config:
+        platform: linux
+        image_resource:
+          type: registry-image
+          source: { repository: google/cloud-sdk }
+        inputs:
+        - { name: artifacts-out }
+        params:
+          GCS_BUCKET: ((staging-gcp-creds.bucket_name))
+          GCS_CREDS: ((staging-gcp-creds.creds_json))
+          GCS_PREFIX: #@ data.values.gh_repository + "-artifacts/fuzz-artifacts"
+        run:
+          path: sh
+          args:
+          - -exc
+          - |
+            set -euo pipefail
+            if ! ls artifacts-out/*.tgz >/dev/null 2>&1; then echo "no artifacts to store"; exit 0; fi
+            printf '%s' "$GCS_CREDS" > /tmp/key.json
+            gcloud auth activate-service-account --key-file=/tmp/key.json >/dev/null
+            gsutil cp artifacts-out/artifacts-v*.tgz "gs://$GCS_BUCKET/$GCS_PREFIX/"
+            echo "stored artifacts"
 on_failure: #@ zenduty_notification_hook()
 on_error: #@ zenduty_notification_hook()
 #@ end

--- a/shared/ci/tasks/fuzz.sh
+++ b/shared/ci/tasks/fuzz.sh
@@ -16,7 +16,8 @@
 #!   FUZZ_SECONDS        seconds to fuzz each target (default: 60)
 #!   FUZZ_JOBS           libFuzzer `-jobs` per target; cores ~= #targets * FUZZ_JOBS
 #!   CORPUS_TARBALL_IN   glob of a corpus tarball to extract before fuzzing
-#!   CORPUS_TARBALL_OUT  path to write the evolved corpus tarball after fuzzing
+#!   CORPUS_TARBALL_OUT    path to write the evolved corpus tarball after fuzzing
+#!   ARTIFACTS_TARBALL_OUT path to write a tarball of crash/oom artifacts (if any)
 #!
 #! A repo may optionally ship a curated seed corpus at `fuzz/seeds/<target>/`
 #! (one input per file). It is merged into `fuzz/corpus/<target>/` before every
@@ -93,12 +94,23 @@ done
 if [ "$rc" -ne 0 ]; then
   echo "==== FUZZ CRASH DETECTED ===="
   find fuzz/artifacts -type f -print || true
-  exit "$rc"
 fi
 
-#! Package the evolved corpus (no-op unless CORPUS_TARBALL_OUT is set).
+#! Always package the corpus and any crash artifacts — even when a target
+#! crashed. A discovery must not discard the run's coverage gains or the
+#! failing input. Packaging runs before the (possible) non-zero exit so the
+#! job's ensure-steps can still upload both; the script still exits non-zero
+#! so the build surfaces the discovery (e.g. via on_failure).
 if [ -n "${CORPUS_TARBALL_OUT:-}" ]; then
   mkdir -p "$(dirname "$CORPUS_TARBALL_OUT")"
   tar -czf "$CORPUS_TARBALL_OUT" -C fuzz corpus
   echo "packaged corpus -> $CORPUS_TARBALL_OUT"
 fi
+if [ -n "${ARTIFACTS_TARBALL_OUT:-}" ] && [ -d fuzz/artifacts ] && \
+   [ -n "$(find fuzz/artifacts -type f 2>/dev/null | head -1)" ]; then
+  mkdir -p "$(dirname "$ARTIFACTS_TARBALL_OUT")"
+  tar -czf "$ARTIFACTS_TARBALL_OUT" -C fuzz artifacts
+  echo "packaged artifacts -> $ARTIFACTS_TARBALL_OUT"
+fi
+
+exit "$rc"


### PR DESCRIPTION
## Problem

A fuzz discovery (crash/OOM) discards the entire run:

1. `fuzz.sh` did `exit "$rc"` **before** the corpus-packaging block, so on a crash nothing got packaged.
2. `store-corpus` is a plain plan step, so Concourse **skips it on task failure**.

Net: one target crashing throws away the other targets' coverage gains **and** the failing input. A 24h run that finds one bug currently loses ~24h of corpus evolution.

Surfaced by cala's first 24h run: `velocity_enforce` OOM'd (upstream [cel-rust#306](https://github.com/cel-rust/cel-rust/issues/306), reached via `CelExpression` deserialization) — without this fix the whole run's corpus + the OOM input would be lost.

## Fix

**`fuzz.sh`**: package the corpus **and** any crash artifacts *regardless* of `rc`, then `exit "$rc"`. New optional `ARTIFACTS_TARBALL_OUT` env var (mirrors `CORPUS_TARBALL_OUT`). The script still exits non-zero on a crash, so the build still surfaces the discovery (`on_failure` / Zenduty).

**`fuzz_job`**:
- `fuzz` task gains an `artifacts-out` output and sets `ARTIFACTS_TARBALL_OUT`.
- `store-corpus` + a new `store-artifacts` move under `ensure:` of the fuzz task → they run on success **and** failure.
- `store-artifacts` uploads `artifacts/` to `gs://$BUCKET/<repo>-artifacts/fuzz-artifacts/` (new prefix; upload-only — findings, not replay inputs).

Result: a discovery still fails the build (Zenduty fires) but the corpus evolution and the failing input are preserved in GCS.

## Compatibility

Purely additive to the job plan; repos with no `fuzz/` crate are unaffected (they don't use `fuzz_job`). Rendered with `ytt` clean.

## Test plan
- [x] `ytt` renders the fragment (cala's full pipeline) without error; `ensure:` wraps `store-corpus` + `store-artifacts`, `artifacts-out`/`ARTIFACTS_TARBALL_OUT` wired.
- [ ] cala bumps its vendir ref to this commit and re-runs (follow-up) — a crash should now still `stored corpus` + `stored artifacts`.
